### PR TITLE
Add anchors during minimization + fix atom id increment

### DIFF
--- a/frontend/static/js/radahn_graph.js
+++ b/frontend/static/js/radahn_graph.js
@@ -468,7 +468,7 @@ radahnGraphUtil.generateMotorsJSON = function(lGraph, selectionTable, unit)
 
 radahnGraphUtil.generateLammpsGroupsJSON = function(anchorTable, unit)
 {
-    anchorNodes = [];
+    let anchorNodes = [];
     // Go though each element of the anchor table
 
     for(const [key, value] of Object.entries(anchorTable))


### PR DESCRIPTION
Add anchors during the minimization when groups are declared.
Fix a bug where the atom IDS of anchor would increment for each run. This was due to a global variable which was supposed to be local.