### PR TITLE
Rotate Z axis

### DIFF
--- a/frontend/static/js/radahn_graph.js
+++ b/frontend/static/js/radahn_graph.js
@@ -266,7 +266,7 @@ radahnGraphUtil.setupRadahnGraph = function(lGraph)
             pz: 0.0,
             ax: 0.0,
             ay: 0.0,
-            ax: 0.0,
+            az: 0.0,
             period: 0.0, 
             angle: 0.0,
             valid: true, 


### PR DESCRIPTION
Fix a bug in the frontend where the z axis was not stored properly in the rotate motor.