### PR TITLE
Fixdependencies

### DIFF
--- a/frontend/static/js/radahn_graph.js
+++ b/frontend/static/js/radahn_graph.js
@@ -410,6 +410,7 @@ radahnGraphUtil.setupRadahnGraph = function(lGraph)
 radahnGraphUtil.checkValid = function(lGraph) {
     let nodes = lGraph._nodes;
     let valid = true;
+    let nodeNames = {}
     nodes.forEach(node => {
         node.onValidate();
         if(!node.properties.valid)
@@ -420,6 +421,16 @@ radahnGraphUtil.checkValid = function(lGraph) {
         else 
         {
             console.log("The motor ", node.properties.name, " is valid");
+        }
+
+        if(node.properties.name in nodeNames)
+        {
+            valid = false;
+            console.error("Multiple motors have the name ", node.properties.name, ". Please ensure that the motors have distincts names.");
+        }
+        else 
+        {
+            nodeNames[node.properties.name] = 0;
         }
     });
 

--- a/frontend/static/js/radahn_graph.js
+++ b/frontend/static/js/radahn_graph.js
@@ -428,6 +428,9 @@ radahnGraphUtil.checkValid = function(lGraph) {
 
 radahnGraphUtil.generateMotorsJSON = function(lGraph, selectionTable, unit)
 {
+    // Process the graph so transfer the dependencies and other links
+    lGraph.runStep(1, false);
+
     let nodes = lGraph._nodes;
 
     //console.log("List of motors:");


### PR DESCRIPTION
Fix the generation of dependencies in the node graph. This was because the graphs needs to run at least 1 step in order for the links to be triggers and transfer data.
Add a security in the frontend to prevent the user from trying to create graphs with duplicated motor names.