### PR TITLE
Disable the context menu. Add screenshot button

### DIFF
--- a/frontend/static/js/project_utils.js
+++ b/frontend/static/js/project_utils.js
@@ -53,7 +53,7 @@ radahnProjectUtils.viewerToArray = function(viewer, frameIndex)
 class RadahnProject {
 
     // We keep everything public for now for simplicity. This is basically just a data storage
-    projectName = "defaultName";
+    projectName = "defaultProjectName";
     xyzContent = "";
     xyzFilename = "";
     potentialContent = "";
@@ -75,7 +75,7 @@ class RadahnProject {
 
     resetProject()
     {
-        this.projectName = "defaultName";
+        this.projectName = "defaultProjectName";
         this.xyzContent = "";
         this.xyzFilename = "";
         this.potentialContent = "";

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -205,6 +205,22 @@
         });
 
         // Forward events from the overlay to the molecule canvas
+        elementMoleculeOverlay.addEventListener('contextmenu', (event) => {
+            event.preventDefault();
+
+            const rect = viewerMolecule.container.getBoundingClientRect();
+            const contextMenuEvent = new MouseEvent('contextmenu', {
+                bubbles: true,
+                cancelable: true,
+                view: window,
+                clientX: event.clientX - rect.left,
+                clientY: event.clientY - rect.top
+            });
+
+            viewerMolecule.container.dispatchEvent(contextMenuEvent);
+        });
+
+
         elementMoleculeOverlay.addEventListener('mousedown', (event) => {
             viewerMolecule.container.dispatchEvent(new MouseEvent('mousedown', event)); // Forward to 3Dmol.js (not the molecule canvas) for selection event);
             if (event.button === 0 && event.shiftKey) {
@@ -1321,6 +1337,14 @@
             }
         }
 
+        window.saveMoleculeScreenshot = function() {
+            // Save the file 
+            let anchorLink = document.getElementById("anchor-screenshot");
+            anchorLink.setAttribute('download', project.projectName + ".png");
+            anchorLink.setAttribute('href', viewerMolecule.getCanvas().toDataURL("image/png").replace("image/png", "image/octet-stream"));
+            anchorLink.click();
+        }
+
         window.onPlayTrajectory = function() {
             console.log("Starting trajectory playback");
             viewerMolecule.animate({loop: "forward", reps:1});
@@ -2113,6 +2137,8 @@
                         <option value="index">Index</option>
                     </select>
                     <button id="toggle-atom-colors" onclick="refreshMolecule()">Update</button>
+                    <a id="anchor-screenshot"></a>
+                    <button id="button-screenshot" onclick="saveMoleculeScreenshot()">Screenshot</button>
                     <div>
                         <label for="display-axis">Axes Display:</label>
                         <input type="checkbox" id="display-axis" name="display-axis" checked onchange="onUpdateArrowCenter()">


### PR DESCRIPTION
Forward the context menu event from the viewer overlay to the molecule viewer and disable the default context menu on the overlay.
Add a button to download a screenshot of the molecule viewer instead to still have the save image feature from the default menu.