### PR TITLE
Auto center for Rotate motor

### DIFF
--- a/frontend/static/js/project_utils.js
+++ b/frontend/static/js/project_utils.js
@@ -156,6 +156,52 @@ class RadahnProject {
         delete this.thermostatList[thermostatName];
     }
 
+    setSelectionPositionsFromXYZ(xyzContent)
+    {
+        // Parse the xyz content
+        const lines = xyzContent.split('\n');
+
+        // The first line is the number of atoms
+        const atomCount = parseInt(lines[0].trim(), 10);
+
+        // The second line is the comment line, usually ignored or used as metadata
+        const comment = lines[1].trim();
+
+        // The remaining lines are the atomic coordinates
+        const atoms = [];
+        for (let i = 2; i < lines.length; i++) {
+            const line = lines[i].trim();
+            if (line) {
+                const [element, x, y, z] = line.split(/\s+/);
+                atoms.push({
+                    element,
+                    x: parseFloat(x),
+                    y: parseFloat(y),
+                    z: parseFloat(z)
+                });
+            }
+        }
+
+        // Now that we have the list of atoms and their positions, we can update each selection list
+        for ( let [name, selection] of Object.entries(this.selectionList)) {
+            let indices = selection.atomIndexes;
+            let avgx = 0;
+            let avgy = 0; 
+            let avgz = 0;
+            indices.forEach((val) => {
+                avgx += atoms[val].x;
+                avgy += atoms[val].y;
+                avgz += atoms[val].z;
+            });
+
+            avgx /= indices.length;
+            avgy /= indices.length;
+            avgz /= indices.length;
+
+            selection.centroid = [avgx, avgy, avgz];
+        };
+    }
+
     declareMinimize()
     {
         this.minimizeConfig = {
@@ -346,6 +392,6 @@ class RadahnProject {
             radahnJSON["nvtConfig"] = this.nvtConfig;
         }
 
-        return JSON.stringify(radahnJSON);
+        return JSON.stringify(radahnJSON, null, 4);
     }
 }

--- a/frontend/static/js/radahn_graph.js
+++ b/frontend/static/js/radahn_graph.js
@@ -269,6 +269,7 @@ radahnGraphUtil.setupRadahnGraph = function(lGraph)
             az: 0.0,
             period: 0.0, 
             angle: 0.0,
+            autocentroid: false,
             valid: true, 
             errorMsg: "OK"
         };
@@ -278,6 +279,7 @@ radahnGraphUtil.setupRadahnGraph = function(lGraph)
         this.widgetPX = this.addWidget("number", "Centroid X (distance unit)", this.properties.px, {property: "px", min: -10000000000.0, max: 10000000000.0, step:1});
         this.widgetPY = this.addWidget("number", "Centroid Y (distance unit)", this.properties.py, {property: "py", min: -10000000000.0, max: 10000000000.0, step:1});
         this.widgetPZ = this.addWidget("number", "Centroid Z (distance unit)", this.properties.pz, {property: "pz", min: -10000000000.0, max: 10000000000.0, step:1});
+        this.widgetAutoCentroid = this.addWidget("toggle", "Auto Centroid", this.properties.autocentroid, {property: "autocentroid"});
         this.widgetAX = this.addWidget("number", "Rotation Axe x", this.properties.ax, {property: "ax", min: -10000000000.0, max: 10000000000.0, step:1});
         this.widgetAY = this.addWidget("number", "Rotation Axe y", this.properties.ay, {property: "ay", min: -10000000000.0, max: 10000000000.0, step:1});
         this.widgetAZ = this.addWidget("number", "Rotation Axe z", this.properties.az, {property: "az", min: -10000000000.0, max: 10000000000.0, step:1});
@@ -323,6 +325,7 @@ radahnGraphUtil.setupRadahnGraph = function(lGraph)
             "px": this.properties.px,
             "py": this.properties.py,
             "pz": this.properties.pz,
+            "autocentroid": this.properties.autocentroid,
             "ax": this.properties.ax,
             "ay": this.properties.ay,
             "az": this.properties.az,
@@ -482,6 +485,18 @@ radahnGraphUtil.generateMotorsJSON = function(lGraph, selectionTable, unit)
                 {
                     nodesArray[i]["selection"][j] = nodesArray[i]["selection"][j] + 1;
                 }
+
+                // Special treatment for the rotate motor 
+                // Ugly approach
+                if(nodesArray[i]["type"] == "rotate" && nodesArray[i]["autocentroid"])
+                {
+                    const centroid = selectionTable[nodesArray[i]["selectionName"]].centroid;
+                    console.log("Requested to auto center the Rotate motor ", nodesArray[i]["name"]);
+                    console.log("Replace center [", nodesArray[i]["px"], ",", nodesArray[i]["py"], ",", nodesArray[i]["pz"], "] by [", centroid[0], ",", centroid[1], ",", centroid[2], "].")
+                    nodesArray[i]["px"] = centroid[0];
+                    nodesArray[i]["py"] = centroid[1];
+                    nodesArray[i]["pz"] = centroid[2];
+                }
             }
             else 
             {
@@ -497,5 +512,5 @@ radahnGraphUtil.generateMotorsJSON = function(lGraph, selectionTable, unit)
     radahnJSON["motors"] = nodesArray;
 
     //console.log(JSON.stringify(radahnJSON));
-    return JSON.stringify(radahnJSON);
+    return JSON.stringify(radahnJSON, null, 4);
 }

--- a/frontend/templates/index.html
+++ b/frontend/templates/index.html
@@ -750,6 +750,11 @@
                 return false;
             }
 
+            // Update the selections with the state which will be used for the simulation
+            console.log("Updating selection information...");
+            project.setSelectionPositionsFromXYZ(xyzData);
+            console.log("Selections updated with the simulation state.");
+
             if(project.potentialContent.length == 0){
                 console.error("No forcefield was loaded. Please load a forcefield before generating inputs. ");
                 return false;
@@ -815,6 +820,9 @@
                 console.error("No molecule was loaded. Please load a molecule before generating inputs. ");
                 return false;
             }
+
+            // Update the selections with the state which will be used for the simulation
+            project.setSelectionPositionsFromXYZ(xyzData);
 
             if(project.potentialContent.length == 0){
                 console.error("No forcefield was loaded. Please load a forcefield before generating inputs. ");
@@ -1747,7 +1755,7 @@
             }
 
             // Update the project motor graph and unit
-            project.setMotorGraph(JSON.stringify(nodeEditor.serialize()), document.getElementById("unit_set").value);
+            project.setMotorGraph(JSON.stringify(nodeEditor.serialize(), null, 4), document.getElementById("unit_set").value);
 
             // Update the NVT section
             refreshMinimizeSetup();
@@ -1762,7 +1770,7 @@
 
             // Save the file 
             //console.log(projectContent);
-            let fileContent = JSON.stringify(projectContent);
+            let fileContent = JSON.stringify(projectContent, null, 4);
             var bb = new Blob([fileContent], {type: 'text/plain'});
             var a = document.createElement('a');
             //let filename = 
@@ -1802,7 +1810,7 @@
             }
 
             // Update the project motor graph and unit
-            project.setMotorGraph(JSON.stringify(nodeEditor.serialize()), document.getElementById("unit_set").value);
+            project.setMotorGraph(JSON.stringify(nodeEditor.serialize(), null, 4), document.getElementById("unit_set").value);
 
             // Update the minimize section
             refreshMinimizeSetup();


### PR DESCRIPTION
Add the option in a RotateMotor to auto center the motor at runtime. When inputs are generated, the frontend use the selection of the motor to calculate the geometric center of the selection and use is at centroid for the rotation. This option can be enabled in each rotate motor individually and is not enabled by default.